### PR TITLE
increase buffer size

### DIFF
--- a/FastestWaysInCSharp/FileProcessing/ParseCsv/SylvanDataCsv.cs
+++ b/FastestWaysInCSharp/FileProcessing/ParseCsv/SylvanDataCsv.cs
@@ -7,7 +7,11 @@ public static class SylvanDataCsv
 {
     public static async IAsyncEnumerable<FakeName> ParseAsync(string filePath)
     {
-        await using var csv = CsvDataReader.Create(filePath);
+        var opts = new CsvDataReaderOptions {
+            BufferSize = 0x100000
+        };
+
+        await using var csv = CsvDataReader.Create(filePath, opts);
 
         while (await csv.ReadAsync())
         {


### PR DESCRIPTION
My library is a bit too conservative in the default buffer size that it uses, and the performance can benefit significantly from being provided a larger buffer. The performance would also be improved if the BirthDay column used ISO8601 format (yyyy-MM-dd), which my library has an optimized fast-path for handling.

It might be worth calling out that some of the other implementations are not full RFC4180 compatible. I know the PipelinesAndSequenceReader code doesn't handle quoted fields and such. It also fails catastrophically if the date is in a different format than expected; it throws an exception if the date is ISO8601, for example.

The repository, and .sln file also have a misspelling: "Fatest".